### PR TITLE
Fix compiler errors and add make clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,7 @@ xattrtest:
 
 checkstyle:
 	git format-patch -k --stdout HEAD^ | ./checkpatch.pl --no-tree
+
+clean:
+	rm -f *.o
+	rm -f xattrtest

--- a/xattrtest.c
+++ b/xattrtest.c
@@ -7,11 +7,15 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <time.h>
 #include <getopt.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/types.h>
+#include <sys/wait.h>
 #include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/xattr.h>
 #include <linux/limits.h>
 
 static const char shortopts[] = "hvycdn:f:x:s:p:t:e:r";
@@ -469,7 +473,6 @@ static int
 unlink_files(void)
 {
 	int i, rc;
-	char name[16];
 	char *file = NULL;
 	struct timeval start, stop, delta;
 


### PR DESCRIPTION
- Include headers to fix implicit declaration warnings
- Remove unused variable
- Add 'make clean' make target

Signed-off-by: Ned Bass <bass6@llnl.gov>